### PR TITLE
Update lambda runtime param to AWS recommended 'nodejs4.3'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = {
                     Handler: handler,
                     Mode: 'event',
                     Role: role,
-                    Runtime: 'nodejs',
+                    Runtime: 'nodejs4.3',
                     MemorySize: memory,
                     Timeout: timeout
                 }, function(err) {


### PR DESCRIPTION
When uploading, I currently get this error message from AWS:

> InvalidParameterValueException: The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions.

This PR is just a minor edit to the Runtime param.   Thanks!